### PR TITLE
Eng 5238 npm publish fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freestar/pubfig-adslot-react-component",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "build-lib": "NODE_ENV=production && mkdir -p ./dist && rm -rf ./dist/* && npx babel src/components/FreestarAdSlot --out-dir dist --copy-files",
-    "publish": "npm publish --access public",
+    "publish-npm": "npm run build-lib && npm publish --access public",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "pubfig",
     "adslot-react-component"
   ],
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": false,
   "repository": {
     "type": "git",


### PR DESCRIPTION
ENG-5238 
Fixed issue with running npm run publish where it would try to publish twice by renaming the publish command. Also added the build command to run prior to publishing to make sure that was never missed


![image](https://user-images.githubusercontent.com/66525000/95931538-45061900-0d7e-11eb-9cc7-e708681d3840.png)
