### PR TITLE
Update to init and load together and prevenut duplicate load using window variable

### DIFF
--- a/src/components/FreestarAdSlot/freestarWrapper.js
+++ b/src/components/FreestarAdSlot/freestarWrapper.js
@@ -1,17 +1,10 @@
 class FreestarWrapper {
 
-  constructor () {
+  init(publisher) {
     window.freestarReactCompontentLoaded = window.freestarReactCompontentLoaded || false
     this.loaded = window.freestarReactCompontentLoaded
-    this.logEnabled = window.location.search.indexOf('fslog') > -1
-  }
-  log (level, ...msg)  {
-    let title = 'Pubfig React Plugin ', styles = 'background: #00C389; color: #fff; border-radius: 3px; padding: 3px'
-    if (this.logEnabled) {
-      console.info(`%c${title}`, styles, ...msg);
-    }
-  }
-  load (publisher) {
+    this.logEnabled = window.location.search.indexOf('fslog') > -1 ? true
+      : window.freestarReactCompontentLogEnabled ? window.freestarReactCompontentLogEnabled : false
     if (!this.loaded) {
       this.loaded = window.freestarReactCompontentLoaded = true
       const qa = window.location.search.indexOf('fsdebug') > -1 ? '/qa' : ''
@@ -29,6 +22,15 @@ class FreestarWrapper {
       this.log(0,"========== LOADING Pubfig ==========")
       document.body.appendChild(script)
     }
+  }
+  log (level, ...msg)  {
+    let title = 'Pubfig React Plugin ', styles = 'background: #00C389; color: #fff; border-radius: 3px; padding: 3px'
+    if (this.logEnabled) {
+      console.info(`%c${title}`, styles, ...msg);
+    }
+  }
+  load (publisher) {
+
   }
 
   newAdSlot (placementName, onNewAdSlotsHook, channel, targeting) {

--- a/src/components/FreestarAdSlot/freestarWrapper.js
+++ b/src/components/FreestarAdSlot/freestarWrapper.js
@@ -29,10 +29,6 @@ class FreestarWrapper {
       console.info(`%c${title}`, styles, ...msg);
     }
   }
-  load (publisher) {
-
-  }
-
   newAdSlot (placementName, onNewAdSlotsHook, channel, targeting) {
     window.freestar.queue.push(() => {
       window.freestar.newAdSlots({

--- a/src/components/FreestarAdSlot/index.js
+++ b/src/components/FreestarAdSlot/index.js
@@ -8,8 +8,7 @@ class FreestarAdSlot extends Component {
   componentDidMount () {
     const { publisher } = this.props
     const { placementName, onNewAdSlotsHook, channel, targeting } = this.props
-
-    Freestar.load(publisher)
+    Freestar.init(publisher)
     Freestar.newAdSlot(placementName, onNewAdSlotsHook, channel, targeting)
   }
 


### PR DESCRIPTION

**ENG-5602 | 1.6**

## Description, Motivation and Context

**What is the goal of ticket?  What are the acceptance criteria?**
Prevent the component from loading the freestar lib multiple times
**What are the changes?**
Merged the init method and load method together and utilized a global variable to track if pubfig was loaded
**Why did you choose this solution?**
Did not want to use the freestar variable since the script could be loading while the component is unmounted and remounted which would prevent that from being caught. 

## Checklist:
[ ] Unit tests are all passing on local.

[ ] I unit tested new functionality.
