### PR TITLE
Eng 5630 allow optional direct to gam ad units

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,13 @@ class Demo extends Component {
     const placementName = 'PublisherName_970x250_728x90_320x50'
     const publisher = 'publisherName'
     const targeting = { key1: 'value1', key2: 'value2' }
-
+    const slotSize = [[300,250], [728,90]]
+    const sizeMapping = [
+        {viewport: [0,0], slot: [300,250]},
+        {viewport: [768, 0], slot: [728,90]}
+    ]
     const { adRefresh } = this.state
-
+    
     return (
       <div>
         <FreestarAdSlot
@@ -46,6 +50,9 @@ class Demo extends Component {
           onNewAdSlotsHook={(placementName) => console.log('creating ad', placementName)}
           onDeleteAdSlotsHook={(placementName) => console.log('destroying ad', placementName)}
           onAdRefreshHook={(placementName) => console.log('refreshing ad', placementName)}
+          adUnitPath='/45796/my_adunit_name'
+          slotSize={slotSize}
+          sizeMapping={sizeMapping}
         />
         <button onClick={this.onAdRefresh}>Trigger Refresh</button>
       </div>
@@ -85,6 +92,26 @@ An *optional* event hook that returns the `placementName` when the component **u
 **onAdRefreshHook**
 An *optional* event hook that returns the `placementName` when the component refreshes an ad.
 
+**adUnitPath**
+An *optional* string with the full GAM ad unit path. This should be used only if you are intending to bypass Freestar placements intentionally.
+
+**slotSize**
+An *optional* string or array as defined by [GPT Documentation](https://developers.google.com/publisher-tag/reference#googletag.GeneralSize). Should only be used in conjuction with `adUnitPath`
+
+**sizeMapping**
+An *optional* array of object which contains an array of viewport size and slot size. To be used in conjunction with `adUnitPath`. This needs to be set if the ad needs to serve different ad size per different view port sizes (responsive ad).
+Setting the `slot` to any dimension that's not configured in DFP results in rendering an empty ad.
+The ad slot size which is provided for the viewport size of [0, 0] will be used as default ad size if none of viewport size matches.
+
+https://support.google.com/dfp_premium/answer/3423562?hl=en
+         
+    e.g.
+         
+    sizeMapping={[
+        {viewport: [0, 0], slot: [320, 50]},
+        {viewport: [768, 0], slot: [728, 90]}
+    ]}
+          
 ### API Methods
 
 **FreestarAdSlot.setPageTargeting**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freestar/pubfig-adslot-react-component",
-  "version": "1.7.0-beta.5",
+  "version": "1.7.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freestar/pubfig-adslot-react-component",
-  "version": "1.7.0-beta.0",
+  "version": "1.7.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freestar/pubfig-adslot-react-component",
-  "version": "1.6.0",
+  "version": "1.7.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freestar/pubfig-adslot-react-component",
-  "version": "1.7.0-beta.2",
+  "version": "1.7.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freestar/pubfig-adslot-react-component",
-  "version": "1.7.0-beta.11",
+  "version": "1.7.0-beta.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freestar/pubfig-adslot-react-component",
-  "version": "1.7.0-beta.6",
+  "version": "1.7.0-beta.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freestar/pubfig-adslot-react-component",
-  "version": "1.7.0-beta.8",
+  "version": "1.7.0-beta.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freestar/pubfig-adslot-react-component",
-  "version": "1.7.0-beta.1",
+  "version": "1.7.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freestar/pubfig-adslot-react-component",
-  "version": "1.7.0-beta.7",
+  "version": "1.7.0-beta.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freestar/pubfig-adslot-react-component",
-  "version": "1.7.0-beta.10",
+  "version": "1.7.0-beta.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freestar/pubfig-adslot-react-component",
-  "version": "1.7.0-beta.3",
+  "version": "1.7.0-beta.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freestar/pubfig-adslot-react-component",
-  "version": "1.7.0-beta.9",
+  "version": "1.7.0-beta.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "pubfig",
     "adslot-react-component"
   ],
-  "version": "1.7.0-beta.1",
+  "version": "1.7.0-beta.2",
   "private": false,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "pubfig",
     "adslot-react-component"
   ],
-  "version": "1.7.0-beta.10",
+  "version": "1.7.0-beta.11",
   "private": false,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "pubfig",
     "adslot-react-component"
   ],
-  "version": "1.7.0-beta.6",
+  "version": "1.7.0-beta.7",
   "private": false,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "pubfig",
     "adslot-react-component"
   ],
-  "version": "1.7.0-beta.0",
+  "version": "1.7.0-beta.1",
   "private": false,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "pubfig",
     "adslot-react-component"
   ],
-  "version": "1.7.0-beta.11",
+  "version": "1.7.0-beta.12",
   "private": false,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "pubfig",
     "adslot-react-component"
   ],
-  "version": "1.6.0",
+  "version": "1.7.0-beta.0",
   "private": false,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "pubfig",
     "adslot-react-component"
   ],
-  "version": "1.7.0-beta.3",
+  "version": "1.7.0-beta.5",
   "private": false,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "pubfig",
     "adslot-react-component"
   ],
-  "version": "1.7.0-beta.8",
+  "version": "1.7.0-beta.9",
   "private": false,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "pubfig",
     "adslot-react-component"
   ],
-  "version": "1.7.0-beta.9",
+  "version": "1.7.0-beta.10",
   "private": false,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "pubfig",
     "adslot-react-component"
   ],
-  "version": "1.7.0-beta.5",
+  "version": "1.7.0-beta.6",
   "private": false,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "pubfig",
     "adslot-react-component"
   ],
-  "version": "1.7.0-beta.2",
+  "version": "1.7.0-beta.3",
   "private": false,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "pubfig",
     "adslot-react-component"
   ],
-  "version": "1.7.0-beta.7",
+  "version": "1.7.0-beta.8",
   "private": false,
   "repository": {
     "type": "git",

--- a/src/components/FreestarAdSlot/freestarWrapper.js
+++ b/src/components/FreestarAdSlot/freestarWrapper.js
@@ -42,8 +42,7 @@ class FreestarWrapper {
       else {
 
         adSlot = window.googletag.defineSlot(adUnitPath, slotSize, placementName).addService(window.googletag.pubads())
-        if (sizeMappings)
-        {
+        if (sizeMappings) {
           const sizeMappingArray = sizeMappings
             .reduce((mapping, size) => {
               return mapping.addSize(size.viewport, size.slot)
@@ -51,6 +50,12 @@ class FreestarWrapper {
             .build()
           adSlot.defineSizeMapping(sizeMappingArray)
 
+        }
+        if (targeting) {
+          Object.entries(targeting).forEach(entry => {
+            const [key, value] = entry;
+            adSlot.setTargeting(key, value);
+          })
         }
         window.googletag.display(adSlot)
 

--- a/src/components/FreestarAdSlot/freestarWrapper.js
+++ b/src/components/FreestarAdSlot/freestarWrapper.js
@@ -41,7 +41,7 @@ class FreestarWrapper {
       }
       else {
 
-        adSlot = window.googletag.defineSlot(adUnitPath, slotSize, placementName)
+        adSlot = window.googletag.defineSlot(adUnitPath, slotSize, placementName).addService(window.googletag.pubads())
         if (sizeMappings)
         {
           const sizeMappingArray = sizeMappings
@@ -52,7 +52,7 @@ class FreestarWrapper {
           adSlot.defineSizeMapping(sizeMappingArray)
 
         }
-        window.googletag.display(adSlot).addService(window.googletag.pubads())
+        window.googletag.display(adSlot)
 
       }
       if (onNewAdSlotsHook) {

--- a/src/components/FreestarAdSlot/freestarWrapper.js
+++ b/src/components/FreestarAdSlot/freestarWrapper.js
@@ -50,8 +50,9 @@ class FreestarWrapper {
             }, window.googletag.sizeMapping())
             .build()
           adSlot.defineSizeMapping(sizeMappingArray)
-          window.googletag.display(adSlot)
+
         }
+        window.googletag.display(adSlot)
 
       }
       if (onNewAdSlotsHook) {

--- a/src/components/FreestarAdSlot/freestarWrapper.js
+++ b/src/components/FreestarAdSlot/freestarWrapper.js
@@ -58,7 +58,7 @@ class FreestarWrapper {
           })
         }
         window.googletag.display(adSlot)
-        window.googletag.refresh(adSlot)
+        window.googletag.pubads().refresh(adSlot)
 
       }
       if (onNewAdSlotsHook) {

--- a/src/components/FreestarAdSlot/freestarWrapper.js
+++ b/src/components/FreestarAdSlot/freestarWrapper.js
@@ -58,6 +58,7 @@ class FreestarWrapper {
           })
         }
         window.googletag.display(adSlot)
+        window.googletag.refresh(adSlot)
 
       }
       if (onNewAdSlotsHook) {

--- a/src/components/FreestarAdSlot/freestarWrapper.js
+++ b/src/components/FreestarAdSlot/freestarWrapper.js
@@ -50,6 +50,7 @@ class FreestarWrapper {
             }, window.googletag.sizeMapping())
             .build()
           adSlot.defineSizeMapping(sizeMappingArray)
+          window.googletag.display(adSlot)
         }
 
       }

--- a/src/components/FreestarAdSlot/freestarWrapper.js
+++ b/src/components/FreestarAdSlot/freestarWrapper.js
@@ -52,7 +52,7 @@ class FreestarWrapper {
           adSlot.defineSizeMapping(sizeMappingArray)
 
         }
-        window.googletag.display(adSlot)
+        window.googletag.display(adSlot).addService(window.googletag.pubads())
 
       }
       if (onNewAdSlotsHook) {

--- a/src/components/FreestarAdSlot/freestarWrapper.js
+++ b/src/components/FreestarAdSlot/freestarWrapper.js
@@ -26,35 +26,63 @@ class FreestarWrapper {
   log (level, ...msg)  {
     let title = 'Pubfig React Plugin ', styles = 'background: #00C389; color: #fff; border-radius: 3px; padding: 3px'
     if (this.logEnabled) {
-      console.info(`%c${title}`, styles, ...msg);
+      console.info(`%c${title}`, styles, ...msg)
     }
   }
-  newAdSlot (placementName, onNewAdSlotsHook, channel, targeting) {
+  newAdSlot (placementName, onNewAdSlotsHook, channel, targeting, adUnitPath, slotSize, sizeMappings) {
     window.freestar.queue.push(() => {
-      window.freestar.newAdSlots({
-        slotId: placementName,
-        placementName,
-        targeting
-      }, channel)
+      let adSlot;
+      if (!adUnitPath) {
+        window.freestar.newAdSlots({
+            slotId: placementName,
+            placementName,
+            targeting
+          }, channel)
+      }
+      else {
+
+        adSlot = window.googletag.defineSlot(adUnitPath, slotSize, placementName)
+        if (sizeMappings)
+        {
+          const sizeMappingArray = sizeMappings
+            .reduce((mapping, size) => {
+              return mapping.addSize(size.viewport, size.slot)
+            }, window.googletag.sizeMapping())
+            .build()
+          adSlot.defineSizeMapping(sizeMappingArray)
+        }
+
+      }
       if (onNewAdSlotsHook) {
         onNewAdSlotsHook(placementName)
       }
+      return adSlot
     })
 
   }
 
-  deleteAdSlot (placementName, onDeleteAdSlotsHook) {
+  deleteAdSlot (placementName, onDeleteAdSlotsHook, adSlot) {
     window.freestar.queue.push(() => {
-      window.freestar.deleteAdSlots({ placementName })
+      if(!adSlot){
+        window.freestar.deleteAdSlots({ placementName })
+      }
+      else {
+        window.googletag.destroySlots([adSlot])
+      }
       if (onDeleteAdSlotsHook) {
         onDeleteAdSlotsHook(placementName)
       }
     })
   }
 
-  refreshAdSlot (placementName, onAdRefreshHook) {
+  refreshAdSlot (placementName, onAdRefreshHook, adSlot) {
     window.freestar.queue.push(() => {
-      window.freestar.freestarReloadAdSlot(placementName)
+      if(!adSlot){
+        window.freestar.freestarReloadAdSlot(placementName)
+      }
+      else {
+        window.googletag.pubads().refresh([adSlot])
+      }
       if (onAdRefreshHook) {
         onAdRefreshHook(placementName)
       }

--- a/src/components/FreestarAdSlot/index.js
+++ b/src/components/FreestarAdSlot/index.js
@@ -8,19 +8,20 @@ class FreestarAdSlot extends Component {
   componentDidMount () {
     const { publisher } = this.props
     const { placementName, onNewAdSlotsHook, channel, targeting } = this.props
+    const { adUnitPath, slotSize, sizeMapping} = this.props;
     Freestar.init(publisher)
-    Freestar.newAdSlot(placementName, onNewAdSlotsHook, channel, targeting)
+    this.adSlot = Freestar.newAdSlot(placementName, onNewAdSlotsHook, channel, targeting, adUnitPath, slotSize, sizeMapping)
   }
 
   componentWillUnmount () {
-    const { placementName, onDeleteAdSlotsHook } = this.props
-    Freestar.deleteAdSlot(placementName, onDeleteAdSlotsHook)
+    const { placementName, onDeleteAdSlotsHook, adUnitPath } = this.props
+    Freestar.deleteAdSlot(placementName, onDeleteAdSlotsHook, this.adSlot)
   }
 
   componentWillReceiveProps (nextProps) {
-    const { placementName, onAdRefreshHook } = this.props
+    const { placementName, onAdRefreshHook, adUnitPath } = this.props
     if (nextProps.adRefresh !== this.props.adRefresh) {
-      Freestar.refreshAdSlot(placementName, onAdRefreshHook)
+      Freestar.refreshAdSlot(placementName, onAdRefreshHook, this.adSlot)
     }
   }
 
@@ -49,14 +50,22 @@ FreestarAdSlot.clearPageTargeting = (key) => {
 
 FreestarAdSlot.propTypes = {
   publisher: PropTypes.string.isRequired,
-  placementName: PropTypes.string.isRequired,
+  placementName: PropTypes.string,
   targeting: PropTypes.object,
   channel: PropTypes.string,
   classList: PropTypes.array,
   adRefresh: PropTypes.number,
   onNewAdSlotsHook: PropTypes.func,
   onDeleteAdSlotsHook: PropTypes.func,
-  onAdRefreshHook: PropTypes.func
+  onAdRefreshHook: PropTypes.func,
+  adUnitPath : PropTypes.string,
+  slotSize : PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
+  sizeMapping: PropTypes.arrayOf(
+    PropTypes.shape({
+      viewport: PropTypes.array,
+      slot: PropTypes.array
+    })
+  )
 }
 
 FreestarAdSlot.defaultProps = {
@@ -68,7 +77,10 @@ FreestarAdSlot.defaultProps = {
   adRefresh: 0,
   onNewAdSlotsHook: () => {},
   onDeleteAdSlotsHook: () => {},
-  onAdRefreshHook: () => {}
+  onAdRefreshHook: () => {},
+  adUnitPath: null,
+  slotSize : null,
+  sizeMapping: null
 }
 
 export default FreestarAdSlot

--- a/src/components/FreestarAdSlot/index.js
+++ b/src/components/FreestarAdSlot/index.js
@@ -50,7 +50,7 @@ FreestarAdSlot.clearPageTargeting = (key) => {
 
 FreestarAdSlot.propTypes = {
   publisher: PropTypes.string.isRequired,
-  placementName: PropTypes.string,
+  placementName: PropTypes.string.isRequired,
   targeting: PropTypes.object,
   channel: PropTypes.string,
   classList: PropTypes.array,

--- a/src/components/FreestarAdSlot/index.js
+++ b/src/components/FreestarAdSlot/index.js
@@ -14,12 +14,12 @@ class FreestarAdSlot extends Component {
   }
 
   componentWillUnmount () {
-    const { placementName, onDeleteAdSlotsHook, adUnitPath } = this.props
+    const { placementName, onDeleteAdSlotsHook } = this.props
     Freestar.deleteAdSlot(placementName, onDeleteAdSlotsHook, this.adSlot)
   }
 
   componentWillReceiveProps (nextProps) {
-    const { placementName, onAdRefreshHook, adUnitPath } = this.props
+    const { placementName, onAdRefreshHook } = this.props
     if (nextProps.adRefresh !== this.props.adRefresh) {
       Freestar.refreshAdSlot(placementName, onAdRefreshHook, this.adSlot)
     }


### PR DESCRIPTION
**ENG-5630**

## Description, Motivation and Context
We needed a way to allow a publisher to load a gam ad unit directly without requiring a freestar placement setup like the could if they were a non react site by using the gpt lib directly. This update allows optional parms to pass to do this which internally will just create the ad unit, display it, refresh it if requested through the component and be destroyed appropriately 
**What is the goal of ticket?  What are the acceptance criteria?**
Allow GAM ad units to be rendered on a page without a freestar placement
**What are the changes?**
I added 3 new attributes `adUnitPath` , `slotSize`, `sizeMapping` to mirror what the nfl react GPT does. Internally i updated our wrapper to send the requests directly to GPT if adUnitPath is supplied

## How Has This Been Tested?  Is there anything you weren't able to fully test?
Testing with Kyle on a sample repo
## Does this change require updates outside of the code, like updating the documentation, adding a feature flag, or adding fields to a DB table? If so, was this done?
no
## Any tickets that this is dependent upon?
np
## Should reviewers manually test your changes?
no
## Checklist:
[ ] Unit tests are all passing on local.

[ ] I unit tested new functionality.
