### PR TITLE
ENG-8335 Updated react component to generate div ids for the ad conta…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4880,6 +4880,11 @@
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "dev": true
     },
+    "random-string": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/random-string/-/random-string-0.2.0.tgz",
+      "integrity": "sha1-pG5DdTUr7amg17DRntbTIezR2C0="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freestar/pubfig-adslot-react-component",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "dependencies": {
     "lodash.isequal": "^4.5.0",
-    "lodash.sortby": "^4.7.0"
+    "lodash.sortby": "^4.7.0",
+    "random-string": "^0.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "pubfig",
     "adslot-react-component"
   ],
-  "version": "3.0.3",
+  "version": "3.1.0",
   "main": "dist/index.js",
   "private": false,
   "repository": {

--- a/src/components/FreestarAdSlot/freestarWrapper.js
+++ b/src/components/FreestarAdSlot/freestarWrapper.js
@@ -120,8 +120,8 @@ class FreestarWrapper {
     }
     return placementName
   }
-  queueNewAdSlot (placementName, onNewAdSlotsHook, channel, targeting, adUnitPath, slotSize, sizeMappings) {
-    const args = {placementName, onNewAdSlotsHook, channel, targeting, adUnitPath, slotSize, sizeMappings}
+  queueNewAdSlot (placementName, slotId,  onNewAdSlotsHook, channel, targeting, adUnitPath, slotSize, sizeMappings) {
+    const args = {placementName, slotId, onNewAdSlotsHook, channel, targeting, adUnitPath, slotSize, sizeMappings}
     this.newAdSlotQueue.push(args);
   }
   async flushQueuedNewAdSlots ()
@@ -151,7 +151,7 @@ class FreestarWrapper {
         }
 
         adMap.channelAdMap[newAdSlot.channel].push({
-          slotId: newAdSlot.placementName,
+          slotId: newAdSlot.slotId,
           placementName: newAdSlot.placementName,
           targeting: newAdSlot.targeting,
           callback: newAdSlot.onNewAdSlotsHook
@@ -160,7 +160,7 @@ class FreestarWrapper {
         return  adMap
       }
       adMap.nonChannelAds.push({
-        slotId: newAdSlot.placementName,
+        slotId: newAdSlot.slotId,
         placementName: newAdSlot.placementName,
         targeting: newAdSlot.targeting,
         callback: newAdSlot.onNewAdSlotsHook
@@ -196,7 +196,7 @@ class FreestarWrapper {
     window.freestar.queue.push(async () => {
       const adSlots = []
       ads.forEach( (ad) => {
-        let adSlot = window.googletag.defineSlot(ad.adUnitPath, ad.slotSize, ad.placementName).addService(window.googletag.pubads())
+        let adSlot = window.googletag.defineSlot(ad.adUnitPath, ad.slotSize, ad.slotId).addService(window.googletag.pubads())
 
         if (ad.sizeMappings) {
           const sizeMappingArray = ad.sizeMappings
@@ -225,15 +225,15 @@ class FreestarWrapper {
       window.googletag.pubads().refresh(adSlots)
       ads.forEach( (ad) => {
         if (ad.onNewAdSlotsHook){
-          ad.onNewAdSlotsHook(ad.placementName)
+          ad.onNewAdSlotsHook(ad.slotId)
         }
       })
     })
   }
 
-  newAdSlot (placementName, onNewAdSlotsHook, channel, targeting, adUnitPath, slotSize, sizeMappings) {
+  newAdSlot (placementName, slotId, onNewAdSlotsHook, channel, targeting, adUnitPath, slotSize, sizeMappings) {
     if (this.queue) {
-      this.queueNewAdSlot(placementName,onNewAdSlotsHook, channel, targeting, adUnitPath, slotSize, sizeMappings)
+      this.queueNewAdSlot(placementName, slotId, onNewAdSlotsHook, channel, targeting, adUnitPath, slotSize, sizeMappings)
     }
     else {
 
@@ -241,7 +241,7 @@ class FreestarWrapper {
         {
           channel,
           placements : [{
-            slotId: placementName,
+            slotId: slotId,
             placementName: placementName,
             targeting
           }]
@@ -250,46 +250,46 @@ class FreestarWrapper {
         if (!adUnitPath) {
 
           this.newPubfigAdSlots(channel, [{
-            slotId: placementName,
+            slotId: slotId,
             placementName: placementName,
             targeting
           }])
 
         } else {
-          this.newDirectGAMAdSlots([{adUnitPath, slotSize, placementName, sizeMappings, targeting}])
+          this.newDirectGAMAdSlots([{adUnitPath, slotId, slotSize, placementName, sizeMappings, targeting}])
         }
       })
     }
   }
 
-  deleteAdSlot (placementName, targeting, onDeleteAdSlotsHook, adUnitPath) {
+  deleteAdSlot (placementName, slotId, targeting, onDeleteAdSlotsHook, adUnitPath) {
     window.freestar.queue.push(async () => {
       if(!adUnitPath){
-        placementName = await this.getMappedPlacementName(placementName, targeting)
-        window.freestar.deleteAdSlots({ placementName })
+        slotId = await this.getMappedPlacementName(slotId, targeting)
+        window.freestar.deleteAdSlots({ slotId })
       }
       else {
         window.googletag.destroySlots([this.adSlotsMap[adUnitPath]])
       }
       if (onDeleteAdSlotsHook) {
-        onDeleteAdSlotsHook(placementName)
+        onDeleteAdSlotsHook(slotId)
       }
     })
   }
 
-  refreshAdSlot (placementName, targeting, onAdRefreshHook, adUnitPath) {
-    this.log(0,`Refreshing Ad slot [${placementName}]`)
+  refreshAdSlot (placement, slotId, targeting, onAdRefreshHook, adUnitPath) {
+    this.log(0,`Refreshing Ad slot [${slotId}]`)
 
     window.freestar.queue.push(async() => {
       if(!adUnitPath){
-        placementName = await this.getMappedPlacementName(placementName, targeting)
-        window.freestar.freestarReloadAdSlot(placementName)
+        slotId = await this.getMappedPlacementName(slotId, targeting)
+        window.freestar.freestarReloadAdSlot(slotId)
       }
       else {
         window.googletag.pubads().refresh([this.adSlotsMap[adUnitPath]])
       }
       if (onAdRefreshHook) {
-        onAdRefreshHook(placementName)
+        onAdRefreshHook(slotId)
       }
     })
   }

--- a/src/components/FreestarAdSlot/index.js
+++ b/src/components/FreestarAdSlot/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Freestar from "./freestarWrapper"
-
+import randomString from 'random-string'
 
 
 
@@ -9,7 +9,8 @@ class FreestarAdSlot extends Component {
   constructor(props) {
     const { placementName } = props
     super(props);
-    this.state = { placementName : placementName }
+    const slotId = `${placementName}-${randomString({length:10, numeric:true, letters:true})}`
+    this.state = { placementName : placementName , slotId : slotId}
   }
 
   async componentDidMount () {
@@ -18,19 +19,20 @@ class FreestarAdSlot extends Component {
 
     await Freestar.init(publisher, keyValueConfigMappingURL)
     const mappedPlacementName = await Freestar.getMappedPlacementName(placementName,targeting)
-    this.setState({placementName: mappedPlacementName})
-    Freestar.newAdSlot(mappedPlacementName, onNewAdSlotsHook, channel, targeting, adUnitPath, slotSize, sizeMapping)
+    const slotId = `${mappedPlacementName}-${randomString({length:10, numeric:true, letters:true})}`
+    this.setState({placementName: mappedPlacementName, slotId: slotId})
+    Freestar.newAdSlot(mappedPlacementName,slotId, onNewAdSlotsHook, channel, targeting, adUnitPath, slotSize, sizeMapping)
   }
 
   componentWillUnmount () {
-    const { placementName, onDeleteAdSlotsHook, targeting, adUnitPath } = this.props
-    Freestar.deleteAdSlot(placementName, targeting, onDeleteAdSlotsHook, adUnitPath)
+    const { onDeleteAdSlotsHook, targeting, adUnitPath } = this.props
+    Freestar.deleteAdSlot(this.state.slotId, targeting, onDeleteAdSlotsHook, adUnitPath)
   }
 
   componentWillReceiveProps (nextProps) {
     const { placementName, onAdRefreshHook, targeting, adUnitPath } = this.props
     if (nextProps.adRefresh !== this.props.adRefresh) {
-      Freestar.refreshAdSlot(placementName, targeting, onAdRefreshHook, adUnitPath)
+      Freestar.refreshAdSlot(placementName, this.state.slotId, targeting, onAdRefreshHook, adUnitPath)
     }
   }
 
@@ -40,10 +42,9 @@ class FreestarAdSlot extends Component {
   }
 
   render() {
-    const { placementName, targeting, placementMappingLocation } = this.props
     return (
       <div>
-        <div className={this.classes()} id={this.state.placementName}></div>
+        <div className={this.classes()} id={this.state.slotId}></div>
       </div>
     )
   }


### PR DESCRIPTION

**[Jira Ticket Link](ENG-8335) | Release Version**

## Description, Motivation and Context
Allow the ability to reuse a placement on the page multiple times. Currently since we generate the underlying container element with the id the same as the placement if the publisher wants to reuse the placement multiple times ( like infinite scroll) they would run into issues. 

**What is the goal of ticket?  What are the acceptance criteria?**
Ensure that the element ids that are created are always unique
**What are the changes?**
appened a random string to the placement name when generating the dom id

**Why did you choose this solution?**
quickest/simplest
## How Has This Been Tested?  Is there anything you weren't able to fully test?
locally on the freestar react project
## Does this change require updates outside of the code, like updating the documentation, adding a feature flag, or adding fields to a DB table? If so, was this done?
no
## Any tickets that this is dependent upon?
no
## Should reviewers manually test your changes?
no
## Checklist:
[ ] Unit tests are all passing on local.

[ ] I unit tested new functionality.
