### PR TITLE
UPDATE deleteAdSlots to pass the slotId instead of object

### DIFF
--- a/src/components/FreestarAdSlot/freestarWrapper.js
+++ b/src/components/FreestarAdSlot/freestarWrapper.js
@@ -246,7 +246,7 @@ class FreestarWrapper {
     window.freestar.queue.push(async () => {
       if(!adUnitPath) {
         slotId = await this.getMappedPlacementName(slotId, targeting)
-        window.freestar.deleteAdSlots({ slotId })
+        window.freestar.deleteAdSlots(slotId);
       } else {
         window.googletag.destroySlots([this.adSlotsMap[adUnitPath]])
       }


### PR DESCRIPTION
Fix the way we are passing the elementId to deleteAdSlot from React.