### PR TITLE
Eng 8663 passthough remove from refresh lib

### DIFF
--- a/src/components/FreestarAdSlot/freestarWrapper.js
+++ b/src/components/FreestarAdSlot/freestarWrapper.js
@@ -248,7 +248,11 @@ class FreestarWrapper {
         slotId = await this.getMappedPlacementName(slotId, targeting)
         window.freestar.deleteAdSlots(slotId);
       } else {
-        window.googletag.destroySlots([this.adSlotsMap[adUnitPath]])
+        const slot = this.adSlotsMap[adUnitPath];
+        if (freestar.refreshLibrary && freestar.refreshLibrary.hasOwnProperty([slot.getSlotElementId()])) {
+          delete freestar.refreshLibrary[slot.getSlotElementId()];
+        }
+        window.googletag.destroySlots([slot])
       }
       if (onDeleteAdSlotsHook) {
         onDeleteAdSlotsHook(placementName)

--- a/src/components/FreestarAdSlot/freestarWrapper.js
+++ b/src/components/FreestarAdSlot/freestarWrapper.js
@@ -61,6 +61,9 @@ class FreestarWrapper {
     }
   }
 
+  refreshExists(slot) {
+    return freestar.refreshLibrary && freestar.refreshLibrary.hasOwnProperty([slot]);
+  }
   /* example mapping
     {
       mappings:
@@ -203,6 +206,9 @@ class FreestarWrapper {
         window.googletag.display(adSlot)
         adSlots.push(adSlot)
         this.adSlotsMap[adSlot.getAdUnitPath()] = adSlot
+        if (!this.refreshExists()) {
+          freestar.refreshLibraryCreator(ad.slotId)
+        }
       })
       window.googletag.pubads().refresh(adSlots)
       ads.forEach((ad) => {
@@ -249,7 +255,7 @@ class FreestarWrapper {
         window.freestar.deleteAdSlots(slotId);
       } else {
         const slot = this.adSlotsMap[adUnitPath];
-        if (freestar.refreshLibrary && freestar.refreshLibrary.hasOwnProperty([slot.getSlotElementId()])) {
+        if (this.refreshExists(slot.getSlotElementId())) {
           delete freestar.refreshLibrary[slot.getSlotElementId()];
         }
         window.googletag.destroySlots([slot])


### PR DESCRIPTION
There is missing logic to remove/add refresh information on RefreshLibrary for passthrough units which is fixed now to prevent components being destroyed and added back to refresh early.