### PR TITLE
PFG-733 added optional SRI attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ An *optional* event hook that returns the `placementName` when the component **u
 
 **onAdRefreshHook**
 An *optional* event hook that returns the `placementName` when the component refreshes an ad.
-       
+
+**integrity**
+An *optional* attribute that when passed enables SRI for our pubfig library. The component will use this value for the integrity attribute when loading pubfig 
 ### API Methods
 
 **FreestarAdSlot.setPageTargeting**

--- a/src/components/FreestarAdSlot/freestarWrapper.js
+++ b/src/components/FreestarAdSlot/freestarWrapper.js
@@ -28,7 +28,7 @@ class FreestarWrapper {
       return [];
     }
   }
-  async init (publisher, keyValueConfigMappingLocation) {
+  async init (publisher, keyValueConfigMappingLocation, integrity) {
     window.freestarReactCompontentLoaded = window.freestarReactCompontentLoaded || false
     this.loaded = window.freestarReactCompontentLoaded
     this.logEnabled = window.location.search.indexOf('fslog') > -1
@@ -47,6 +47,9 @@ class FreestarWrapper {
       const script = document.createElement('script')
       script.src = url
       script.async = true
+      if (integrity !== null){
+        script.integrity = integrity
+      }
       this.log(0,'========== LOADING Pubfig ==========')
       document.body.appendChild(script)
       if (keyValueConfigMappingLocation && this.keyValueConfigMappings.length === 0) {

--- a/src/components/FreestarAdSlot/index.js
+++ b/src/components/FreestarAdSlot/index.js
@@ -11,10 +11,21 @@ class FreestarAdSlot extends Component {
   }
 
   async componentDidMount () {
-    const { adUnitPath, slotSize, sizeMapping, placementName, onNewAdSlotsHook, channel, targeting, keyValueConfigMappingURL, publisher } = this.props
+    const {
+      adUnitPath,
+      slotSize,
+      sizeMapping,
+      placementName,
+      onNewAdSlotsHook,
+      channel,
+      targeting,
+      keyValueConfigMappingURL,
+      publisher,
+      integrity
+    } = this.props
     const { slotId } = this.state
 
-    await Freestar.init(publisher, keyValueConfigMappingURL)
+    await Freestar.init(publisher, keyValueConfigMappingURL, integrity)
     const mappedPlacementName = await Freestar.getMappedPlacementName(placementName,targeting)
     this.setState({placementName: mappedPlacementName})
     Freestar.newAdSlot(mappedPlacementName,slotId, onNewAdSlotsHook, channel, targeting, adUnitPath, slotSize, sizeMapping)
@@ -87,7 +98,8 @@ FreestarAdSlot.propTypes = {
     })
   ),
   keyValueConfigMappingURL: PropTypes.string,
-  queue: PropTypes.bool
+  queue: PropTypes.bool,
+  integrity: PropTypes.string
 }
 
 FreestarAdSlot.defaultProps = {
@@ -104,7 +116,8 @@ FreestarAdSlot.defaultProps = {
   adUnitPath: null,
   slotSize : null,
   sizeMapping: null,
-  keyValueConfigMappingURL: null
+  keyValueConfigMappingURL: null,
+  integrity: null
 }
 
 export default FreestarAdSlot


### PR DESCRIPTION
Update to allow for SRI to be passed to the script tag we generate and inject

**[PFG-733] | Release Version**

## Description, Motivation and Context

**What is the goal of ticket?  What are the acceptance criteria?**
Allow publishers to pass the SRI value to the component to be used on the script tag we inject for pubfig
**What are the changes?**
Added optional `integrity` attribute that when passed will be added to the script tag that is generated
**Why did you choose this solution?**
simplest
## How Has This Been Tested?  Is there anything you weren't able to fully test?
n/a
## Does this change require updates outside of the code, like updating the documentation, adding a feature flag, or adding fields to a DB table? If so, was this done?
no
## Any tickets that this is dependent upon?
no
## Should reviewers manually test your changes?
yes
## Checklist:
[ ] Unit tests are all passing on local.

[ ] I unit tested new functionality.


[PFG-733]: https://freestar.atlassian.net/browse/PFG-733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ