### PR TITLE
PFG-3176 insert pubfig script tag into head instead of body

### DIFF
--- a/src/components/FreestarAdSlot/freestarWrapper.js
+++ b/src/components/FreestarAdSlot/freestarWrapper.js
@@ -52,7 +52,7 @@ class FreestarWrapper {
         script.crossOrigin='anonymous'
       }
       this.log(0,'========== LOADING Pubfig ==========')
-      document.body.appendChild(script)
+      document.head.appendChild(script)
       if (keyValueConfigMappingLocation && this.keyValueConfigMappings.length === 0) {
         this.keyValueConfigMappings = await this.fetchKeyValueConfigMapping(keyValueConfigMappingLocation)
       }


### PR DESCRIPTION
Insert pubfig script tag into head instead of body in order to speed up the loading for sites that use infinite scroll