### PR TITLE
Set phoenix-rising as CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @freestarcapital/phoenix
+* @freestarcapital/phoenix-rising


### PR DESCRIPTION
Sets root CODEOWNERS to `* @freestarcapital/phoenix-rising` per the repo-ownership audit (PLAT-1585).