### PR TITLE
fix: [PFG-5360] fall back to legacy GPT API when config API is absent

### DIFF
--- a/src/components/FreestarAdSlot/freestarWrapper.js
+++ b/src/components/FreestarAdSlot/freestarWrapper.js
@@ -1,6 +1,7 @@
 // Load the full build.
 import isEqual from 'lodash.isequal'
 import sortBy from 'lodash.sortby'
+import { setSlotTargeting, setPageTargeting, clearPageTargeting } from './gptConfigApi'
 class FreestarWrapper {
   constructor () {
     this.pageKeyValuePairs = {}
@@ -208,7 +209,7 @@ class FreestarWrapper {
           adSlot.defineSizeMapping(sizeMappingArray)
         }
         if (ad.targeting) {
-          adSlot.setConfig({ targeting: ad.targeting });
+          setSlotTargeting({ slot: adSlot, value: ad.targeting })
         }
         window.googletag.display(adSlot)
         adSlots.push(adSlot)
@@ -289,7 +290,7 @@ class FreestarWrapper {
     window.freestar = window.freestar || {}
     window.freestar.queue =  window.freestar.queue || []
     window.freestar.queue.push(() => {
-      window.googletag.setConfig({ targeting: { [key]: value } })
+      setPageTargeting({ gpt: window.googletag, key, value })
     })
     this.pageKeyValuePairs[key] = value
   }
@@ -298,11 +299,7 @@ class FreestarWrapper {
     window.freestar = window.freestar || {}
     window.freestar.queue =  window.freestar.queue || []
     window.freestar.queue.push(() => {
-      if (key) {
-        window.googletag.setConfig({ targeting: { [key]: null } })
-      } else {
-        window.googletag.setConfig({ targeting: null })
-      }
+      clearPageTargeting({ gpt: window.googletag, key })
     })
     if (key) {
       delete this.pageKeyValuePairs[key]

--- a/src/components/FreestarAdSlot/gptConfigApi.js
+++ b/src/components/FreestarAdSlot/gptConfigApi.js
@@ -1,0 +1,76 @@
+/**
+ * GPT config-API compatibility layer.
+ *
+ * This component does not control the load order of gpt.js on the page. A
+ * non-Freestar, older, or cached gpt.js can own the shared `window.googletag`
+ * global, and that gpt.js has no `setConfig`/`getConfig` — calling it throws
+ * `TypeError: ... is not a function`. Every one of our config-API calls happens
+ * inside a `window.freestar.queue` callback, so the throw kills the rest of that
+ * callback: in `newDirectGAMAdSlots` the slot never reaches `display()`, never
+ * lands in the refresh array, and the `onNewAdSlotsHook` never fires.
+ *
+ * Each helper feature-detects the config API and otherwise routes to the legacy
+ * `pubads()`/slot targeting API, which has existed for the lifetime of GPT and
+ * is safe to assume when any gpt.js is present. Nothing here throws when the
+ * API surface is missing — it falls back or no-ops.
+ *
+ * Ported from pubfig.js `src/core/base/gam/configApi.js`; only the helpers this
+ * component actually calls are included.
+ */
+
+const supportsConfigSetter = (gpt) => typeof gpt?.setConfig === 'function'
+const pubadsOf = (gpt) => (typeof gpt?.pubads === 'function' ? gpt.pubads() : null)
+
+/** GPT targeting values must be a string or an array of strings. */
+const normalize = (value) => (Array.isArray(value) ? value.map(String) : String(value))
+
+/**
+ * Set slot-level targeting. Accepts either a single key/value pair or a full
+ * targeting map (object). Falls back to the legacy `slot.setTargeting` when the
+ * slot lacks the config API — so KVPs are still applied, not silently dropped.
+ */
+export const setSlotTargeting = ({ slot, key, value }) => {
+  if (!slot || value == null) return
+
+  let map
+  if (key) {
+    map = { [key]: normalize(value) }
+  } else if (typeof value === 'object' && !Array.isArray(value)) {
+    map = Object.fromEntries(Object.entries(value).map(([k, v]) => [k, normalize(v)]))
+  } else {
+    return
+  }
+
+  if (supportsConfigSetter(slot)) {
+    slot.setConfig({ targeting: map })
+    return
+  }
+  if (typeof slot.setTargeting === 'function') {
+    Object.entries(map).forEach(([k, v]) => slot.setTargeting(k, v))
+  }
+}
+
+/** Set one page-level (global) targeting key. */
+export const setPageTargeting = ({ gpt, key, value }) => {
+  const normalized = normalize(value)
+  if (supportsConfigSetter(gpt)) {
+    gpt.setConfig({ targeting: { [key]: normalized } })
+    return
+  }
+  pubadsOf(gpt)?.setTargeting(key, normalized)
+}
+
+/** Clear one page-level targeting key, or all of them when `key` is omitted. */
+export const clearPageTargeting = ({ gpt, key }) => {
+  if (supportsConfigSetter(gpt)) {
+    gpt.setConfig({ targeting: key ? { [key]: null } : null })
+    return
+  }
+  const pubads = pubadsOf(gpt)
+  if (!pubads) return
+  if (key) {
+    pubads.clearTargeting(key)
+  } else {
+    pubads.clearTargeting()
+  }
+}


### PR DESCRIPTION
## Problem

A non-Freestar, older, or cached `gpt.js` can own the shared `window.googletag` global without the newer `setConfig` config API. Since #71 migrated this component's targeting calls to `setConfig`, those call sites throw `TypeError: ... is not a function` on such pages.

Every one of them runs inside a `window.freestar.queue` callback, so the throw kills the rest of that callback. In `newDirectGAMAdSlots` that means the slot never reaches `display()`, never lands in the `adSlots` refresh array, and `onNewAdSlotsHook` never fires — the ad silently doesn't render.

## Fix

Ports the approach from [pubfig.js#4203](https://github.com/freestarcapital/pubfig.js/pull/4203).

Adds `src/components/FreestarAdSlot/gptConfigApi.js`, a compatibility layer that feature-detects the config API and otherwise routes to the legacy `pubads()`/slot targeting API, and routes all four config-API call sites in `freestarWrapper.js` through it.

| Call site | Config API | Legacy fallback |
|---|---|---|
| `newDirectGAMAdSlots` slot targeting | `slot.setConfig({ targeting })` | `slot.setTargeting(k, v)` per entry |
| `setPageTargeting` | `googletag.setConfig({ targeting: { [key]: value } })` | `pubads().setTargeting(key, value)` |
| `clearPageTargeting(key)` | `setConfig({ targeting: { [key]: null } })` | `pubads().clearTargeting(key)` |
| `clearPageTargeting()` | `setConfig({ targeting: null })` | `pubads().clearTargeting()` |

Targeting values are coerced to `string` / `string[]`, as the legacy API requires — a publisher passing a number or boolean would otherwise break the fallback path.

Only the three helpers this component actually calls were ported. Upstream's `applyDisableInitialLoad`, `applySingleRequest`, `applyCollapseEmptyDivs`, `applySlotForceSafeFrame`, and the two getters have no call sites here, so they'd be dead weight in the bundle. Exported names and signatures match upstream so the two files stay diffable.

## Verification

Exercised the helpers against stub googletag/slot objects:

| Scenario | Result |
|---|---|
| Legacy `gpt.js` (no `setConfig`) | `slot.setTargeting` / `pubads().setTargeting` / `clearTargeting(key)` / `clearTargeting()` all called correctly |
| Modern `gpt.js` | `setConfig` only — legacy stubs rigged to throw were never reached |
| Neither API present / null slot / junk values | No throw, no calls |

Coercion on the legacy path: `42` → `"42"`, `[1,2]` → `["1","2"]`, `true` → `"true"`.

Bundle built clean and contains both branches.

## Notes

No unit tests added — the repo has no test runner (`"test": "echo No Tests Configured"`). Upstream's `configApi.spec.js` is a good starting point if we add jest here later.

Unrelated, but worth flagging: `npm run build` fails on Node 20 with `ERR_OSSL_EVP_UNSUPPORTED` (webpack 5.15). This reproduces on a clean `master`, so it predates this PR, but it will bite whoever cuts the next release. Workaround is `NODE_OPTIONS=--openssl-legacy-provider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)