### PR TITLE
Move JF_URL/JF_USER from secrets to org variables

### DIFF
--- a/.github/workflows/frogbot.yml
+++ b/.github/workflows/frogbot.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: jfrog/frogbot@v2
         env:
-          JF_URL: ${{ secrets.JF_URL }}
+          JF_URL: ${{ vars.JF_URL }}
           JF_ACCESS_TOKEN: ${{ secrets.JF_ACCESS_TOKEN }}
           JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JF_GIT_BASE_BRANCH: ${{ matrix.branch }}


### PR DESCRIPTION
Part of PLAT-1583: JF_URL and JF_USER are not credentials (a URL and a service-account username), so they belong in org variables, not secrets. Same values, no functional change — JF_ACCESS_TOKEN (the real credential) is untouched.