### PR TITLE
chore: cover more Terraform file types in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,9 @@
 * @freestarcapital/phoenix-rising
 *.tf   @freestarcapital/platform
+*.tf.json         @freestarcapital/platform
+*.tfvars          @freestarcapital/platform
+*.tfvars.json     @freestarcapital/platform
+*.tfstate         @freestarcapital/platform
+*.tfstate.backup  @freestarcapital/platform
+*.tfplan          @freestarcapital/platform
+**/.terraform.lock.hcl  @freestarcapital/platform


### PR DESCRIPTION
Extends the PLAT-1592 Terraform CODEOWNERS rule to cover .tfvars, .tfstate, .tfplan, .terraform.lock.hcl, and their variants, per Horacio's request.

Part of the GitHub Governance rollout (PLAT-1484).